### PR TITLE
Add Template card

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,8 @@
   "image": "ludeeus/container:monster",
   "context": "..",
   "appPort": [
-    "5000:5000",
-    "9123:8123"
+    "5001:5000",
+    // "9123:8123"
   ],
   "postCreateCommand": "npm install",
   "runArgs": [

--- a/src/helpers/dashboards.ts
+++ b/src/helpers/dashboards.ts
@@ -1,5 +1,5 @@
 import { Dashboard, DashboardCard, DashboardConfig, DashboardView } from '../types';
-import { updateCardTemplate } from './templates';
+import { extractTemplateData, updateCardTemplate } from './templates';
 
 export const parseDashboards = (data) => {
   const dashboards: Record<string, Dashboard> = {};
@@ -23,7 +23,7 @@ export const parseDashboardGenerator = (dashboardId, dashboardUrl) => {
     if (dashboardConfig.template) {
       dashboardConfig.views.forEach((view) => {
         if (view.cards?.length == 1) {
-          response.templates[`${view.path}`] = view.cards[0];
+          response.templates[`${view.path}`] = extractTemplateData(view.cards[0]);
         }
       });
     }

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -22,6 +22,19 @@ export const getTemplatesUsedInView = (view: DashboardView): string[] => {
 
 const replaceRegex = /(?<!\\)\$([^\$]+)(?!\\)\$/gm;
 
+export const extractTemplateData = (data: DashboardCard): DashboardCard => {
+  const dataFromTemplate = {};
+  let template = JSON.stringify(data);
+  template = template.replaceAll(replaceRegex, (substring, templateKey) => {
+    if (dataFromTemplate[templateKey] === undefined) {
+      dataFromTemplate[templateKey] = '';
+    }
+    return dataFromTemplate[templateKey] || substring;
+  });
+  data.template_data = { ...data.template_data, ...dataFromTemplate };
+  return data;
+};
+
 export const updateCardTemplate = (data: DashboardCard, templateData: Record<string, any> = {}): DashboardCard => {
   // Get key and data for template
   const templateKey = data.template;

--- a/src/linked-lovelace-template.ts
+++ b/src/linked-lovelace-template.ts
@@ -4,15 +4,13 @@ import { LitElement, html, TemplateResult, css, PropertyValues, CSSResultGroup }
 import { customElement, property, state } from 'lit/decorators';
 import { HomeAssistant, hasConfigOrEntityChanged, LovelaceCardEditor, getLovelace } from 'custom-card-helpers'; // This is a community maintained npm module with common helper functions/types. https://github.com/custom-cards/custom-card-helpers
 
-import type { DashboardView, LinkedLovelaceTemplateCardConfig } from './types';
+import type { LinkedLovelaceTemplateCardConfig } from './types';
 import './types';
-import { LIB_VERSION } from './version';
 import { localize } from './localize/localize';
 import { LinkedLovelaceTemplateCardEditor } from './template-editor';
 import StaticLinkedLovelace from './shared-linked-lovelace';
 import { log } from './helpers';
 
-log(`Template card`);
 // This puts your card into the UI card picker dialog
 (window as any).customCards = (window as any).customCards || [];
 (window as any).customCards.push({

--- a/src/template-editor.ts
+++ b/src/template-editor.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { LitElement, html, TemplateResult, css, CSSResultGroup } from 'lit';
+import { HomeAssistant, fireEvent, LovelaceCardEditor } from 'custom-card-helpers';
+
+import { ScopedRegistryHost } from '@lit-labs/scoped-registry-mixin';
+import { DashboardCard, LinkedLovelaceTemplateCardConfig } from './types';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { customElement, property, state } from 'lit/decorators';
+import { formfieldDefinition } from '../elements/formfield';
+import { selectDefinition } from '../elements/select';
+import { switchDefinition } from '../elements/switch';
+import { textfieldDefinition } from '../elements/textfield';
+import StaticLinkedLovelace from './shared-linked-lovelace';
+
+@customElement('linked-lovelace-template-editor')
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export class LinkedLovelaceTemplateCardEditor extends ScopedRegistryHost(LitElement) implements LovelaceCardEditor {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _config?: LinkedLovelaceTemplateCardConfig;
+
+  @state() private _helpers?: any;
+
+  private _initialized = false;
+
+  static elementDefinitions = {
+    ...textfieldDefinition,
+    ...selectDefinition,
+    ...switchDefinition,
+    ...formfieldDefinition,
+  };
+
+  public setConfig(config: LinkedLovelaceTemplateCardConfig): void {
+    this._config = config;
+
+    this.loadCardHelpers();
+  }
+
+  protected shouldUpdate(): boolean {
+    if (!this._initialized) {
+      this._initialize();
+    }
+
+    return true;
+  }
+
+  get _template(): string {
+    return this._config?.template || '';
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this.hass || !this._helpers) {
+      return html``;
+    }
+
+    return html`
+      <div class="linked-lovelace-config">
+        <mwc-textfield
+          label="Template Name"
+          .value=${this._template}
+          .configValue=${'template'}
+          @input=${this._valueChanged}
+        ></mwc-textfield>
+        <p>Options:</p>
+        <ul>
+          ${Object.keys(StaticLinkedLovelace.instance.templates).map((template) => html`<li>${template}</li>`)}
+        </ul>
+      </div>
+    `;
+  }
+
+  private _initialize(): void {
+    if (this.hass === undefined) return;
+    if (this._config === undefined) return;
+    if (this._helpers === undefined) return;
+    this._initialized = true;
+  }
+
+  private async loadCardHelpers(): Promise<void> {
+    this._helpers = await (window as any).loadCardHelpers();
+  }
+
+  private _valueChanged(ev): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+    const target = ev.target;
+    if (this[`_${target.configValue}`] === target.value) {
+      return;
+    }
+    if (target.configValue) {
+      if (target.value === '') {
+        const tmpConfig = { ...this._config };
+        delete tmpConfig[target.configValue];
+        if (target.configValue === 'template') {
+          tmpConfig['template_data'] = {};
+        }
+        this._config = tmpConfig;
+      } else {
+        let templateData = {};
+        if (target.configValue === 'template') {
+          const template: DashboardCard | undefined = StaticLinkedLovelace.instance.templates[target.value];
+          console.log(template, target.value);
+          if (template) {
+            templateData = template.template_data || {};
+          }
+        }
+        this._config = {
+          ...this._config,
+          template_data: templateData,
+          [target.configValue]: target.checked !== undefined ? target.checked : target.value,
+        };
+      }
+    }
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  static styles: CSSResultGroup = css`
+    .linked-lovelace-config {
+      display: flex;
+      flex-direction: column;
+    }
+    .linked-lovelace-config > * {
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
+    mwc-select,
+    mwc-textfield {
+      margin-bottom: 16px;
+      display: block;
+    }
+    mwc-formfield {
+      padding-bottom: 8px;
+    }
+    mwc-switch {
+      --mdc-theme-secondary: var(--switch-checked-color);
+    }
+    ul {
+      max-height: 500px;
+      overflow-y: scroll;
+    }
+  `;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,13 @@ export interface LinkedLovelaceCardConfig extends LovelaceCardConfig {
   debug: boolean;
 }
 
+export interface LinkedLovelaceTemplateCardConfig extends LovelaceCardConfig {
+  type: string;
+  template: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  template_data: Record<string, any>
+}
+
 export interface Dashboard {
   id: string;
   mode: string;


### PR DESCRIPTION
Adds a card `type: custom:linked-lovelace-template` that allows for easier selection of existing templates when adding a new card.
<img width="834" alt="image" src="https://user-images.githubusercontent.com/6538753/202833605-fbd9f07a-6a42-4462-9529-263c9f1a1f6d.png">
 The config also is populated in the card editor with the template data for a card when a valid name is put in the text field
<img width="836" alt="image" src="https://user-images.githubusercontent.com/6538753/202833609-1370c023-fe28-4df3-b68b-e7572733878e.png">
