### PR TITLE
Don't try and match invalid var characters

### DIFF
--- a/src/helpers/templates.test.ts
+++ b/src/helpers/templates.test.ts
@@ -252,4 +252,47 @@ describe('[function] updateCardTemplate', () => {
       },
     });
   });
+
+  test('ignores invalid characters in varible names', () => {
+    const template: DashboardCard = {
+      type: 'template',
+      name: '$cool {{}{$ $cool$ man',
+    };
+    const card: DashboardCard = {
+      type: 'test',
+      template: 'template',
+      template_data: {
+        cool: 'yes',
+      },
+    };
+    expect(updateCardTemplate(card, { template })).toStrictEqual({
+      type: 'template',
+      template: 'template',
+      name: '$cool {{}{$ yes man',
+      template_data: {
+        cool: 'yes',
+      },
+    });
+  });
+  test('allows for alphanumeric and underscores in varible names', () => {
+    const template: DashboardCard = {
+      type: 'template',
+      name: '$cool_123$ man',
+    };
+    const card: DashboardCard = {
+      type: 'test',
+      template: 'template',
+      template_data: {
+        cool_123: 'yes',
+      },
+    };
+    expect(updateCardTemplate(card, { template })).toStrictEqual({
+      type: 'template',
+      template: 'template',
+      name: 'yes man',
+      template_data: {
+        cool_123: 'yes',
+      },
+    });
+  });
 });

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -23,7 +23,7 @@ export const getTemplatesUsedInView = (view: DashboardView): string[] => {
   );
 };
 
-const replaceRegex = /(?<!\\)\$([^\$]+)(?!\\)\$/gm;
+const replaceRegex = /(?<!\\)\$([a-z|A-Z|0-9|\_]+)(?!\\)\$/gm;
 
 export const extractTemplateData = (data: DashboardCard): DashboardCard => {
   const dataFromTemplate = data.template_data || {};


### PR DESCRIPTION
Only allow alphanumeric and underscores in variable names to be replaces. This was matching any $ in the file before, even if it was just a normal character. Example template - this would break on the '$' in the template

```
type: custom:button-card
entity: sensor.docker_$containerName$_status
name: $fullContainerName$
icon: $icon$
styles:
  button-card:
    - font-size: 20px
    - width: 100%
  grid:
    - width: 100%
    - grid-template-areas: '"i n memory" "i n status"'
    - grid-template-columns: 1fr 2fr 3fr
    - grid-template-rows: min-content min-content
  name:
    - font-weight: bold
    - padding-right: 40px
  icon:
    - width: 60px
  custom_fields:
    status:
      - align-self: start
      - text-align: start
      - padding-right: 20px
      - padding-bottom: 4px
    memory:
      - align-self: start
      - text-align: start
      - padding-right: 20px
      - padding-bottom: 4px
custom_fields:
  memory: |
    [[[
      return `<ha-icon
        icon="mdi:memory"
        style="width: 20px; height: 20px; color: deepskyblue; padding-right: 8px">
        </ha-icon><span>RAM: <span style="color: var(--text-color-sensor);">${states['sensor.docker_$containerName$_memory'].state}mb</span></span>`
    ]]]
  status: |
    [[[
      return `<ha-icon
        icon="mdi:server"
        style="width: 20px; height: 20px; color: deepskyblue; padding-right:8px">
        </ha-icon><span>Status: <span style="color: var(--text-color-sensor);">${states['sensor.docker_$containerName$_status'].state}</span></span>`
    ]]]
```
