### PR TITLE
Fix max stack call bug, and allow nested templates on any object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linked-lovelace-ui",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Linked Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/src/helpers/templates.test.ts
+++ b/src/helpers/templates.test.ts
@@ -252,4 +252,77 @@ describe('[function] updateCardTemplate', () => {
       },
     });
   });
+
+  test('does not replace child card with template if card is template', () => {
+    const template: DashboardCard = {
+      type: 'template',
+      card: {
+        type: 'swapped',
+        template: 'template'
+      }
+    };
+    const card: DashboardCard = {
+      type: 'test',
+      template: 'template',
+      card:
+      {
+        type: 'test',
+        template: 'template',
+      }
+    };
+    expect(updateCardTemplate(card, { template })).toStrictEqual({
+      type: 'template',
+      template: 'template',
+      card: {
+        type: 'swapped',
+        template: 'template',
+      },
+    });
+  });
+
+  test('does not replace child card with template if card is template', () => {
+    const template: DashboardCard = {
+      type: 'new',
+      card: {
+        type: 'swapped',
+        template: 'template'
+      }
+    };
+    const card: DashboardCard = {
+      type: 'test',
+      tap_action: {
+        action: 'fire-dom-event',
+        browser_mod: {
+          service: 'browser_mod.popup',
+          data: {
+            title: '',
+            content: {
+              type: 'old',
+              template: 'template'
+            }
+          }
+        }
+      }
+    };
+    expect(updateCardTemplate(card, { template })).toStrictEqual({
+      type: 'test',
+      tap_action: {
+        action: 'fire-dom-event',
+        browser_mod: {
+          service: 'browser_mod.popup',
+          data: {
+            title: '',
+            content: {
+              type: 'new',
+              template: 'template',
+              card: {
+                type: 'swapped',
+                template: 'template'
+              }
+            }
+          }
+        }
+      }
+    });
+  });
 });

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -71,25 +71,37 @@ export const updateCardTemplate = (data: DashboardCard, templateData: Record<str
     }
     // Put template key back in card
     data = { ...{ template: templateKey, ...data }, template: templateKey };
-  }
-  if (data.cards) {
-    // Update any cards in the card
-    const cards: DashboardCard[] = [];
-    data.cards.forEach((card) => {
+  } else {
+    if (data.cards) {
+      // Update any cards in the card
+      const cards: DashboardCard[] = [];
+      data.cards.forEach((card) => {
+        if (dataFromTemplate) {
+          // Pass template data down to children
+          card.template_data = { ...(card.template_data || {}), ...dataFromTemplate };
+        }
+        cards.push(Object.assign({}, updateCardTemplate(card, templateData)));
+      });
+      data.cards = cards;
+    }
+    if (data.card) {
       if (dataFromTemplate) {
         // Pass template data down to children
-        card.template_data = { ...(card.template_data || {}), ...dataFromTemplate };
+        data.card.template_data = { ...(data.card.template_data || {}), ...dataFromTemplate };
       }
-      cards.push(Object.assign({}, updateCardTemplate(card, templateData)));
-    });
-    data.cards = cards;
-  }
-  if (data.card) {
-    if (dataFromTemplate) {
-      // Pass template data down to children
-      data.card.template_data = { ...(data.card.template_data || {}), ...dataFromTemplate };
+      data.card = Object.assign({}, updateCardTemplate(data.card, templateData));
     }
-    data.card = Object.assign({}, updateCardTemplate(data.card, templateData));
+    // this handles all nested objects that may contain a template, like tap actions
+    const cardKeys = Object.keys(data);
+    const updatedData = {}
+    cardKeys.forEach((cardKey) => {
+      if (typeof data[cardKey] === 'object') {
+        updatedData[cardKey] = updateCardTemplate(data[cardKey], templateData)
+      }
+    })
+    Object.keys(updatedData).forEach((k) => {
+      data[k] = updatedData[k]
+    })
   }
   return data;
 };


### PR DESCRIPTION
This pull request will fix a max stack call bug that can be hit by nesting templates that have templates in them.

It should not cause any regressions, as it only caused updates to fail.

This pull request also allows any card with an object at any level containing "template" to be updated, this is to support tap actions and browser mod. 

Fixes #13 