### PR TITLE
redesign: comprehensive tests and expanded docs

### DIFF
--- a/docs_site/.vitepress/config.mts
+++ b/docs_site/.vitepress/config.mts
@@ -3,12 +3,14 @@ import { defineConfig } from 'vitepress'
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Linked Lovelace",
-  description: "Usage and Development Notes",
+  description: "Reusable card templates for Home Assistant dashboards",
   base: "/linked-lovelace-ui/",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Home', link: '/' }
+      { text: 'Home', link: '/' },
+      { text: 'Getting Started', link: '/getting-started' },
+      { text: 'API Reference', link: '/api-reference' },
     ],
 
     sidebar: [
@@ -21,11 +23,34 @@ export default defineConfig({
           { text: 'Providing Template Context', link: '/providing-template-context' },
           { text: 'Creating Partials', link: '/creating-partials' },
         ]
-      }
+      },
+      {
+        text: 'Reference',
+        items: [
+          { text: 'API Reference', link: '/api-reference' },
+          { text: 'Template Syntax', link: '/template-syntax' },
+        ]
+      },
+      {
+        text: 'Guides',
+        items: [
+          { text: 'Advanced Features', link: '/advanced-features' },
+          { text: 'Troubleshooting', link: '/troubleshooting' },
+        ]
+      },
     ],
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/daredoes/linked-lovelace-ui' }
-    ]
+    ],
+
+    search: {
+      provider: 'local'
+    },
+
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © Daniel Evans'
+    }
   }
 })

--- a/docs_site/advanced-features.md
+++ b/docs_site/advanced-features.md
@@ -1,0 +1,250 @@
+---
+outline: deep
+---
+
+# Advanced Features
+
+---
+
+## ll_keys In Depth
+
+`ll_keys` is the mechanism for **dynamically injecting rendered card objects** into a template. It is most useful when a template has an array property (like `cards`) that should be populated from context.
+
+### The Problem
+
+If you put card objects directly in `ll_context.cards`, the Eta engine serializes them as a JSON string. The result is a string in a field that expects an array of objects.
+
+`ll_keys` tells Linked Lovelace: _"take this context property, render any `ll_template` references within it, and inject the result as a proper object/array into the named template field."_
+
+### How It Works
+
+```yaml
+# Template: row-of-buttons
+ll_key: row-of-buttons
+type: horizontal-stack
+cards: []   # placeholder – will be overwritten by ll_keys
+```
+
+Consumer card:
+
+```yaml
+type: custom:linked-lovelace-template
+ll_template: row-of-buttons
+ll_context:
+  cards:
+    - ll_template: my-button
+      ll_context:
+        name: Lights
+        entity: light.kitchen
+    - ll_template: my-button
+      ll_context:
+        name: Fan
+        entity: fan.bedroom
+ll_keys:
+  cards: cards   # KEY and VALUE must be the same property name
+```
+
+After sync, the `cards` array in `row-of-buttons` is replaced with the fully-rendered button cards.
+
+::: info ll_keys format
+Each entry is `{ propertyName: propertyName }`. Both key and value are the **same string** – the name of the context property (and the template property) to inject.
+:::
+
+### Supported Value Types
+
+| Context value type | Behaviour |
+|--------------------|-----------|
+| Primitive (string, number) | Copies the value directly into the template property |
+| Plain object | Passes through `updateCardTemplate`; template references inside it are rendered |
+| Array of objects | Each item passes through `updateCardTemplate`; items with `ll_template` are rendered |
+
+### Priority for Nested Cards
+
+When using `ll_keys` to inject card arrays, the `ll_priority` of the **inner** templates controls the order they are registered. Make sure all referenced templates have a lower `ll_priority` than the outer template that uses `ll_keys`.
+
+---
+
+## Template Priority
+
+### Why Priority Matters
+
+Templates are registered in order of `ll_priority` (ascending). When a template is registered, it is immediately rendered against all previously registered templates. This means:
+
+- A template with `ll_priority: 0` is registered first and cannot reference templates registered later.
+- A template with `ll_priority: 10` sees all templates with `ll_priority: 0–9` already in the registry.
+
+```yaml
+# This should have a LOWER priority – it is referenced by others
+ll_key: icon-chip
+ll_priority: 0
+type: custom:mushroom-chips-card
+chips:
+  - type: entity
+    entity: "<%= context.entity %>"
+
+# This references icon-chip, so it needs a HIGHER priority
+ll_key: room-row
+ll_priority: 10
+type: horizontal-stack
+cards:
+  - ll_template: icon-chip
+    ll_context:
+      entity: light.kitchen
+```
+
+### Default Priority
+
+All templates default to `ll_priority: 0`. Explicit values are only needed when you have dependencies between templates.
+
+---
+
+## Nested Templates
+
+Templates can reference other templates. There are two patterns:
+
+### Pattern 1 – Registration-Time Nesting
+
+Register a dependency first (lower priority), then register the parent at a higher priority. The parent template body is rendered against the already-registered child template at registration time.
+
+```yaml
+# child.yaml (ll_priority: 0)
+ll_key: status-badge
+ll_priority: 0
+type: custom:mushroom-chips-card
+chips:
+  - type: template
+    entity: "<%= context.entity %>"
+
+# parent.yaml (ll_priority: 10)
+ll_key: room-card
+ll_priority: 10
+type: vertical-stack
+cards:
+  - ll_template: status-badge   # resolved at registration time
+    ll_context:
+      entity: "<%= context.entity %>"
+```
+
+### Pattern 2 – Runtime Injection via ll_keys
+
+Use `ll_keys` to inject template arrays at sync-time rather than registration-time. This is more flexible because the child templates are evaluated with the context available when the consumer card is rendered.
+
+See [ll_keys In Depth](#ll-keys-in-depth) above for details.
+
+---
+
+## Partials
+
+Partials are Eta template snippets, not full card configs. They are ideal for logic that appears in multiple templates – for example, mapping a mode name to an icon.
+
+### Defining Partials
+
+```yaml
+type: custom:linked-lovelace-partials
+partials:
+  - key: stateColor
+    priority: 0
+    template: |-
+      <% const s = (context.state || '').toLowerCase() _%>
+      <%_ if (s === 'on') { _%>green
+      <%_ } else if (s === 'unavailable') { _%>red
+      <%_ } else { _%>grey
+      <%_ } _%>
+
+  - key: entityIcon
+    priority: 0
+    template: |-
+      <% const d = (context.domain || '') _%>
+      <%_ if (d === 'light') { _%>mdi:lightbulb
+      <%_ } else if (d === 'switch') { _%>mdi:toggle-switch
+      <%_ } else { _%>mdi:help-circle
+      <%_ } _%>
+```
+
+### Using Partials in Templates
+
+```yaml
+ll_key: status-chip
+type: custom:mushroom-chips-card
+chips:
+  - type: template
+    entity: "<%= context.entity %>"
+    icon_color: "<%~ include('stateColor', context) %>"
+    icon: "<%~ include('entityIcon', { domain: context.entity.split('.')[0] }) %>"
+```
+
+### Loading Partials From a URL
+
+```yaml
+type: custom:linked-lovelace-partials
+partials:
+  - key: myRemotePartial
+    url: https://raw.githubusercontent.com/you/repo/main/partials/my-partial.eta
+    priority: 5
+```
+
+The URL is fetched at sync-time. Make sure the endpoint is CORS-accessible from your Home Assistant instance's browser.
+
+---
+
+## Context Inheritance
+
+Context flows **downward** through the card tree. When a non-template card (one without `ll_template`) contains child cards, it passes its accumulated context as `parentContext` to each child. The child can supplement or override it with its own `ll_context`.
+
+```
+View
+└── grid card (no ll_template)          parentContext: {}
+    └── fake card (ll_template: btn)    sees parentContext + own ll_context
+        ll_context: { label: "Hi" }
+```
+
+**Rules:**
+1. `ll_context` on a consumer card merges with `parentContext` (parent wins for keys not overridden by child).
+2. `ll_context` on a **source** card (the template definition itself) provides the default context merged in at render time.
+3. Template bodies are rendered as strings – child cards inside a template body are **not** automatically re-rendered with context propagation; use `ll_keys` for that.
+
+---
+
+## The Status Card
+
+The `custom:linked-lovelace-status` card is the control panel for Linked Lovelace. It should be placed on one dashboard (typically a dedicated "admin" view).
+
+### What It Does
+
+1. **Collects** all partials and templates from every dashboard.
+2. **Renders** preview diffs between the current state and the updated state.
+3. **Pushes** the updated configurations to all dashboards when you click Apply.
+
+### Dry Run Mode
+
+Enable Dry Run to preview the diff without making any changes. This is the default for the first run.
+
+### Tabs
+
+| Tab | Description |
+|-----|-------------|
+| Dashboards | Shows affected dashboards with before/after diff |
+| Templates | Lists all registered template source cards |
+| Partials | Lists all registered Eta partials |
+| Logs | Runtime output for debugging |
+
+---
+
+## Migration From V1
+
+V1 used a different key scheme. The key differences:
+
+| Feature | V1 | V2 |
+|---------|----|----|
+| Template source marker | `ll_v1_key` | `ll_key` |
+| Consumer card | `type: linked-lovelace` | `type: custom:linked-lovelace-template` |
+| Template engine | Custom | Eta JS |
+| Variable syntax | `{{ variable }}` | `<%= context.variable %>` |
+| Partial support | ❌ | ✅ |
+| Sections support | ❌ | ✅ (HA 2024.3+) |
+
+V1 cards continue to work in V2 but will be deprecated. Migrate by:
+
+1. Renaming `ll_v1_key` → `ll_key` on source cards.
+2. Updating consumer cards from `type: linked-lovelace` to `type: custom:linked-lovelace-template`.
+3. Replacing `{{ variable }}` syntax with `<%= context.variable %>`.

--- a/docs_site/api-reference.md
+++ b/docs_site/api-reference.md
@@ -1,0 +1,185 @@
+---
+outline: deep
+---
+
+# API Reference
+
+Complete reference for all Linked Lovelace card types and their configuration keys.
+
+---
+
+## Card Types
+
+### `custom:linked-lovelace-template`
+
+The **consumer** card. Place this wherever you want a template to appear. It is replaced at sync-time with the rendered output of the referenced template.
+
+```yaml
+type: custom:linked-lovelace-template
+ll_template: my-template-key
+ll_context:
+  variable1: value1
+  variable2: value2
+ll_keys:
+  cards: cards
+ll_priority: 0
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `ll_template` | `string` | ✅ | Key of the template to use (must match an `ll_key` on a source card). |
+| `ll_context` | `object` | — | Variables passed to the Eta template engine. Accessible as `context.variableName`. |
+| `ll_keys` | `object` | — | Maps a template property to a context value, enabling dynamic injection of rendered sub-cards. See [ll_keys](#ll-keys). |
+| `ll_priority` | `number` | — | Load order for this template reference. Lower numbers run first. Defaults to `0`. |
+
+---
+
+### `custom:linked-lovelace-status`
+
+The **control** card. Add this to any dashboard to see which templates are registered, preview diffs, and push updates to your dashboards.
+
+```yaml
+type: custom:linked-lovelace-status
+```
+
+No additional configuration keys are required. The card provides an interactive UI with the following tabs:
+
+- **Dashboards** – see which dashboards will be affected and preview the diff
+- **Templates** – list of all registered `ll_key` cards
+- **Partials** – list of all registered Eta partials
+- **Logs** – runtime log output
+
+---
+
+### `custom:linked-lovelace-partials`
+
+The **partial definition** card. Defines reusable Eta template snippets that can be called with `<%~ include('partialName', context) %>` inside any template.
+
+```yaml
+type: custom:linked-lovelace-partials
+partials:
+  - key: modeToIcon
+    template: |-
+      <% let mode = (context.mode || '').toLowerCase() _%>
+      <%_ if (mode === 'off') { _%>mdi:power
+      <%_ } else { _%>mdi:progress-question
+      <%_ } _%>
+  - key: remotePartial
+    url: https://example.com/my-partial.eta
+    priority: 10
+```
+
+#### Partial object
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `key` | `string` | ✅ | Name used to call this partial with `include()`. |
+| `template` | `string` | ✅ (or `url`) | Inline Eta template string. |
+| `url` | `string` | ✅ (or `template`) | URL to fetch the template from at run-time. |
+| `priority` | `number` | — | Load order. Lower numbers are loaded first. Defaults to `0`. |
+
+::: tip
+When both `template` and `url` are supplied, `url` takes precedence. Use `priority` when one partial depends on another.
+:::
+
+---
+
+## Source Card Keys
+
+Any existing card can become a **template source** by adding `ll_key` to its YAML. These keys do **not** affect how the card looks or behaves in the UI.
+
+### `ll_key`
+
+```yaml
+ll_key: my-button
+type: button
+name: My Button
+```
+
+- **Type:** `string`
+- Marks the card as a reusable template. The value becomes the identifier used by `ll_template` on consumer cards.
+- Must be unique across all dashboards.
+- Breaks the visual card editor (expected behaviour).
+
+### `ll_priority`
+
+```yaml
+ll_key: complex-card
+ll_priority: 10
+type: custom:...
+```
+
+- **Type:** `number` (default `0`)
+- Controls the order in which templates are registered. A template with `ll_priority: 10` is registered after one with `ll_priority: 0`. This lets higher-priority templates reference lower-priority ones.
+
+### `ll_context`
+
+```yaml
+ll_key: help-button
+ll_context:
+  message: A user needs help
+  title: Help Wanted!
+type: button
+name: "<%= context.title %>"
+```
+
+- **Type:** `object`
+- When placed on a **source** card, provides default variable values shown in the card editor.
+- When placed on a **consumer** card (`ll_template`), provides the variable values used during rendering.
+- Child cards inherit the context accumulated so far as `parentContext`.
+
+### `ll_keys`
+
+```yaml
+ll_template: list-template
+ll_context:
+  myCards:
+    - ll_template: item-template
+      ll_context:
+        label: First
+    - ll_template: item-template
+      ll_context:
+        label: Second
+ll_keys:
+  cards: cards
+```
+
+- **Type:** `Record<string, string>`
+- A map where both key and value are the **same context property name**. Each entry causes the system to:
+  1. Read the context array/object for that property.
+  2. Render any `ll_template` references found within it.
+  3. Inject the rendered result into the corresponding template property.
+- See [ll_keys in depth](./advanced-features#ll-keys-in-depth) for full details.
+
+---
+
+## Template Syntax
+
+Templates use **[Eta JS](https://eta.js.org/)** with `varName: 'context'` and `autoEscape: false`.
+
+| Syntax | Purpose |
+|--------|---------|
+| `<%= context.name %>` | Output the value of `name` |
+| `<%~ include('partial', context) %>` | Include an Eta partial |
+| `<% if (condition) { %> ... <% } %>` | Conditional block |
+| `<% for (let x of arr) { %> ... <% } %>` | Loop |
+| `<%_ ... _%>` | Trim surrounding whitespace |
+
+::: warning
+Missing context variables render as the string `"undefined"`. Use conditionals to provide defaults:
+
+```
+<% context.name ? context.name : 'Default' %>
+```
+:::
+
+See the full [Template Syntax Guide](./template-syntax) for examples.
+
+---
+
+## Key Interactions & Rendering Order
+
+1. The Status card collects all **partials** (`custom:linked-lovelace-partials`) from all dashboards and registers them with Eta.
+2. It collects all **source cards** (`ll_key`) and registers them as templates, sorted by `ll_priority` (ascending).
+3. When syncing a dashboard, each card is recursively traversed. Cards with `ll_template` are replaced with the rendered template output.
+4. Context flows **downward**: a `ll_context` on a consumer card is merged with any `parentContext` inherited from containing non-template cards.

--- a/docs_site/index.md
+++ b/docs_site/index.md
@@ -4,19 +4,27 @@ layout: home
 
 hero:
   name: "Linked Lovelace"
-  text: "Usage and Development Notes"
-  tagline: A Front-End Home Assistant Plugin
+  text: "Reusable Card Templates"
+  tagline: Keep your Home Assistant dashboards in sync with zero copy-pasting.
   actions:
     - theme: brand
       text: Get Started
       link: /getting-started
+    - theme: alt
+      text: API Reference
+      link: /api-reference
 
 features:
-  - title: Reusable Cards
-    details: No more copy-pasting changes for cards between Views/Dashboards
-  - title: Advanced Templating
-    details: Pass down variables to a template, and have it pass those down to another template!
-  - title: Powered by ETA JS
-    details: Using ETA JS to power the templating, you can use most any of the features there such as partials!
+  - title: Define Once, Use Everywhere
+    details: Mark any card with ll_key and it becomes a template. Place it on as many dashboards as you like – one click syncs them all.
+  - title: Dynamic Variables
+    details: Pass ll_context to inject variables at render-time. Different dashboards can use the same template with different values.
+  - title: Eta JS Templating
+    details: Full if/else, loops, and partials via Eta JS. Write logic once in a partial and reuse it across all your templates.
+  - title: ll_keys for Card Arrays
+    details: Dynamically inject rendered card objects into template arrays. Build rows, lists, and grids with a single template.
+  - title: Sections Support
+    details: Works with the Home Assistant 2024.3+ sections dashboard layout out of the box.
+  - title: Verified by Tests
+    details: Core rendering logic is covered by a comprehensive test suite. Consistent output you can rely on.
 ---
-

--- a/docs_site/template-syntax.md
+++ b/docs_site/template-syntax.md
@@ -1,0 +1,258 @@
+---
+outline: deep
+---
+
+# Template Syntax
+
+Linked Lovelace templates use **[Eta JS](https://eta.js.org/)** – a fast, lightweight templating engine. This page is a focused reference for using Eta inside your Home Assistant card configs.
+
+::: info Key settings
+- Variable object: `context` (not `it`)
+- Auto-escape: **disabled** (raw output – needed for YAML values)
+- Whitespace trimming: available with `_` modifiers
+:::
+
+---
+
+## Outputting Variables
+
+Use `<%= %>` to output the value of a context variable.
+
+```yaml
+# Template source card (ll_key: room-button)
+ll_key: room-button
+ll_context:
+  room: Kitchen
+  entity: light.kitchen
+type: custom:button-card
+entity: "<%= context.entity %>"
+name: "<%= context.room %>"
+```
+
+Consumer card:
+
+```yaml
+type: custom:linked-lovelace-template
+ll_template: room-button
+ll_context:
+  room: Living Room
+  entity: light.living_room
+```
+
+Result after sync:
+
+```yaml
+type: custom:button-card
+entity: light.living_room
+name: Living Room
+ll_template: room-button
+ll_context:
+  room: Living Room
+  entity: light.living_room
+```
+
+---
+
+## Default Values
+
+Eta does not support a native default-value operator, but you can use JavaScript's `||` or a ternary:
+
+```yaml
+name: "<%= context.label || 'Unnamed' %>"
+```
+
+```yaml
+# Ternary
+icon: "<%= context.icon ? context.icon : 'mdi:help-circle' %>"
+```
+
+---
+
+## Conditionals
+
+Use JavaScript `if/else` inside `<% %>` blocks:
+
+```yaml
+# Template: status-icon
+ll_key: status-icon
+type: custom:mushroom-template-card
+icon: |-
+  <% if (context.state === 'on') { %>
+  mdi:lightbulb
+  <% } else if (context.state === 'unavailable') { %>
+  mdi:lightbulb-off-outline
+  <% } else { %>
+  mdi:lightbulb-off
+  <% } %>
+```
+
+Consumer:
+
+```yaml
+type: custom:linked-lovelace-template
+ll_template: status-icon
+ll_context:
+  state: "on"
+```
+
+::: tip Whitespace trimming
+Use `_%>` or `<%_` to trim whitespace around a tag:
+
+```
+<%_ if (context.active) { _%>mdi:power<%_ } _%>
+```
+
+This produces `mdi:power` without extra spaces or newlines.
+:::
+
+---
+
+## Loops
+
+Iterate over a context array to generate repeated content:
+
+```yaml
+ll_key: entity-list
+type: custom:auto-entities
+filter:
+  include: []
+card_param: entities
+entities: |-
+  <% for (let e of context.entities) { %>
+  - entity: <%= e %>
+  <% } %>
+```
+
+> **Note:** Loops produce YAML strings inline. Prefer [ll_keys](./advanced-features#ll-keys-in-depth) when you need to dynamically inject rendered card objects into an array.
+
+---
+
+## Partials
+
+Partials are reusable Eta snippets defined with `custom:linked-lovelace-partials`. Include them with `<%~ include('key', data) %>`.
+
+### Defining a partial
+
+```yaml
+type: custom:linked-lovelace-partials
+partials:
+  - key: modeToIcon
+    template: |-
+      <% let mode = (context.mode || '').toLowerCase() _%>
+      <%_ if (mode === 'off') { _%>mdi:power
+      <%_ } else if (mode === 'movie') { _%>mdi:video
+      <%_ } else if (mode === 'party') { _%>mdi:party-popper
+      <%_ } else { _%>mdi:progress-question
+      <%_ } _%>
+```
+
+### Using a partial
+
+```yaml
+ll_key: mode-button
+ll_context:
+  mode: Movie
+type: custom:button-card
+icon: "<%~ include('modeToIcon', { ...context }) %>"
+name: "<%= context.mode %>"
+```
+
+Consumer:
+
+```yaml
+type: custom:linked-lovelace-template
+ll_template: mode-button
+ll_context:
+  mode: Party
+```
+
+Result:
+
+```yaml
+type: custom:button-card
+icon: mdi:party-popper
+name: Party
+ll_template: mode-button
+ll_context:
+  mode: Party
+```
+
+### Passing extra data to a partial
+
+```yaml
+icon: "<%~ include('modeToIcon', { mode: context.hvacMode, extra: 'value' }) %>"
+```
+
+---
+
+## Complex Object Values
+
+Context variables can hold objects and arrays. Access nested properties with standard JavaScript dot notation:
+
+```yaml
+ll_context:
+  device:
+    name: Thermostat
+    entity: climate.living_room
+```
+
+```yaml
+entity: "<%= context.device.entity %>"
+name: "<%= context.device.name %>"
+```
+
+---
+
+## Practical Example: Mushroom Chip with Dynamic Icon and Color
+
+```yaml
+# Partial: chipColor
+type: custom:linked-lovelace-partials
+partials:
+  - key: chipColor
+    template: |-
+      <%_ if (context.state === 'on') { _%>green<%_ } else { _%>grey<%_ } _%>
+
+# Template: room-chip
+ll_key: room-chip
+ll_context:
+  entity: light.example
+  label: Room
+  state: "off"
+type: custom:mushroom-chips-card
+chips:
+  - type: template
+    entity: "<%= context.entity %>"
+    content: "<%= context.label %>"
+    icon_color: "<%~ include('chipColor', context) %>"
+```
+
+Consumer:
+
+```yaml
+type: custom:linked-lovelace-template
+ll_template: room-chip
+ll_context:
+  entity: light.kitchen
+  label: Kitchen
+  state: "on"
+```
+
+---
+
+## Syntax Quick Reference
+
+| Goal | Syntax |
+|------|--------|
+| Output variable | `<%= context.key %>` |
+| Output partial | `<%~ include('partialName', context) %>` |
+| Silent code (no output) | `<% let x = 1 %>` |
+| If block | `<% if (cond) { %> ... <% } %>` |
+| If/else | `<% if (a) { %> ... <% } else { %> ... <% } %>` |
+| For loop | `<% for (const x of arr) { %> ... <% } %>` |
+| Trim leading whitespace | `<%_ ... %>` |
+| Trim trailing whitespace | `<% ... _%>` |
+| Trim both | `<%_ ... _%>` |
+| Default value | `<%= context.x \|\| 'default' %>` |
+| Ternary | `<%= context.x ? context.x : 'fallback' %>` |
+| Null-safe access | `<%= context.obj?.key %>` |

--- a/docs_site/troubleshooting.md
+++ b/docs_site/troubleshooting.md
@@ -1,0 +1,163 @@
+---
+outline: deep
+---
+
+# Troubleshooting
+
+---
+
+## Plugin Not Loading
+
+**Symptom:** No `linked-lovelace-*` card types are available; no log message appears in the browser console.
+
+**Check list:**
+
+1. **HACS installation** – In Home Assistant go to HACS → Frontend and confirm that "Linked Lovelace" appears and has a checkmark.
+2. **Resource registration** – Go to Settings → Dashboards → ⋮ → Manage resources and confirm that `/hacsfiles/linked-lovelace-ui/linked-lovelace-ui.js` is listed as a JavaScript module.
+3. **Hard reload** – After installing, do a hard reload in the browser (`Ctrl+Shift+R` / `Cmd+Shift+R`). Service workers can cache the old state.
+4. **Browser console** – Open DevTools (F12) → Console. Look for errors mentioning `linked-lovelace`.
+
+---
+
+## Template Not Found
+
+**Symptom:** A consumer card renders as an error card with "Template not found" or the card appears empty.
+
+**Check list:**
+
+1. Confirm the `ll_key` value on the source card matches the `ll_template` value on the consumer card exactly (case-sensitive).
+2. Ensure the source card (`ll_key`) is on a dashboard that was loaded before the Status card ran. All dashboards are scanned, but if the source card's dashboard hasn't been saved yet the template won't be found.
+3. Open the Status card → Templates tab and verify the template key appears in the list.
+
+---
+
+## Template Variables Show As "undefined"
+
+**Symptom:** Output contains the literal string `undefined` where a variable value was expected.
+
+**Causes:**
+
+- The context key does not match between `ll_context` and the `<%= context.key %>` expression (typo, case mismatch).
+- The context key is missing on the consumer card and no default is provided.
+
+**Fix:** Add a default value:
+
+```yaml
+# Before
+name: "<%= context.label %>"
+
+# After – with fallback
+name: "<%= context.label || 'Default Name' %>"
+```
+
+Or verify spelling:
+
+```yaml
+ll_context:
+  label: My Room    # must match context.label in the template
+```
+
+---
+
+## Sync Does Not Update All Dashboards
+
+**Symptom:** Some dashboards are updated but others are not.
+
+**Check list:**
+
+1. **Admin access** – Linked Lovelace runs in the browser context. If your user does not have admin access to a dashboard it cannot write to it.
+2. **YAML-mode dashboards** – Dashboards managed in `configuration.yaml` or `ui-lovelace.yaml` are **read-only** via the API. Linked Lovelace cannot modify them.
+3. **Network / WebSocket errors** – Check the Logs tab in the Status card for WebSocket errors when fetching dashboard configs.
+
+---
+
+## Diff Shows Unexpected Changes
+
+**Symptom:** The Status card diff shows changes on cards that should not have been modified.
+
+**Causes:**
+
+- A previous sync added `ll_context` or `ll_template` metadata to cards that were not originally marked as consumers. This can happen if `ll_context` was accidentally left on a template source card.
+- The Eta engine renders template syntax found in non-linked cards (e.g. a card that happens to contain `<%= ... %>` in a string value).
+
+**Fix:**
+
+- On source cards (`ll_key`), remove `ll_context` if you do not want default context written back to the source card. Default context is informational only and is not required for rendering.
+- Escape angle brackets in non-template strings if they accidentally match Eta syntax.
+
+---
+
+## Partial Not Rendering
+
+**Symptom:** `<%~ include('myPartial', context) %>` outputs an empty string or throws an error.
+
+**Check list:**
+
+1. Confirm the `custom:linked-lovelace-partials` card is on a dashboard and was loaded by the Status card before the template that uses it.
+2. Verify the `key` in the partials card exactly matches the string in `include()`.
+3. For URL-loaded partials, open the browser DevTools → Network tab and confirm the URL is reachable and returns plain text.
+4. Check the Logs tab for errors mentioning the partial key.
+5. Verify partial priority: if partial A includes partial B, partial B must have a **lower** `priority` value (loaded first).
+
+---
+
+## ll_keys Not Injecting Cards
+
+**Symptom:** The rendered template still shows an empty `cards: []` instead of the injected cards.
+
+**Check list:**
+
+1. Both the key and value in `ll_keys` must be the **same string** and must match a property on the template and a property in `ll_context`.
+
+   ```yaml
+   # Correct
+   ll_keys:
+     cards: cards
+
+   # Wrong – key and value differ
+   ll_keys:
+     cards: myCards
+   ```
+
+2. The context property must be an **array of objects** (not strings) for cards to be rendered.
+3. Each object in the array that you want rendered must have `ll_template` set.
+4. Make sure the referenced templates are registered before the parent template (`ll_priority`).
+
+---
+
+## Changes Are Not Persistent After HA Restart
+
+**Symptom:** After a Home Assistant restart, dashboards revert to the template placeholders.
+
+**Explanation:** Linked Lovelace modifies dashboard configs stored in the `.storage/lovelace.*` files. These changes **are** persistent across restarts. If you are seeing reverts, one of these is likely happening:
+
+1. A Home Assistant update reset the storage file.
+2. Another tool or automation is overwriting the dashboard config.
+3. The dashboard is in YAML mode and the `ui-lovelace.yaml` file is the source of truth.
+
+**Best practice:** After a successful sync, make a backup of your Home Assistant configuration.
+
+---
+
+## Debugging Tips
+
+### Browser Console
+
+The most information-rich debugging source. Open DevTools (F12) and look for messages prefixed with `[linked-lovelace]`.
+
+### Status Card Logs Tab
+
+The Logs tab shows a timestamped log of all operations the plugin performed, including which templates were found and any errors encountered.
+
+### Dry Run
+
+Before applying changes to all dashboards, use Dry Run mode to preview the diff on individual dashboards. This helps identify unexpected changes before they are written.
+
+### Isolate With A Test Dashboard
+
+Create a dedicated dashboard with only:
+1. The `custom:linked-lovelace-status` card
+2. Your template source cards
+3. One or two consumer cards
+
+This makes it easy to iterate quickly without affecting your production dashboards.

--- a/src/controllers/eta.test.ts
+++ b/src/controllers/eta.test.ts
@@ -1,6 +1,11 @@
 import { DashboardPartialsCard, LINKED_LOVELACE_PARTIALS } from '../types';
 import EtaTemplateController from './eta';
 
+// Mock axios to avoid live network calls in tests
+jest.mock('axios', () => ({
+  get: jest.fn().mockResolvedValue({ data: 'testtest' })
+}));
+
 describe('[class] TemplateController', () => {
   test('sets up as expected', () => {
     const controller = new EtaTemplateController();

--- a/src/helpers/templates.extended.test.ts
+++ b/src/helpers/templates.extended.test.ts
@@ -1,0 +1,594 @@
+/**
+ * Extended tests for updateCardTemplate and related helpers.
+ *
+ * These tests focus on:
+ *  - Consistent, deterministic output (regression suite)
+ *  - All documented ll_* feature flags
+ *  - Context inheritance through the parentContext parameter
+ *  - Sections support (HA 2024.3+ layout)
+ *  - Edge-cases that have caused real bugs (see PR #37, #41)
+ */
+
+import { DashboardCard, DashboardView } from '../types';
+import { updateCardTemplate } from './templates';
+
+// ---------------------------------------------------------------------------
+// Context variable substitution
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] context variable substitution', () => {
+  const template: DashboardCard = {
+    type: 'custom:button-card',
+    name: '<%= context.label %>',
+    icon: '<%= context.icon %>',
+  };
+  const templates = { 'my-button': template };
+
+  test('renders a single string variable', () => {
+    const card: DashboardCard = {
+      type: 'custom:linked-lovelace-template',
+      ll_template: 'my-button',
+      ll_context: { label: 'Lights', icon: 'mdi:lightbulb' },
+    };
+    const result = updateCardTemplate(card, templates);
+    expect(result.name).toBe('Lights');
+    expect(result.icon).toBe('mdi:lightbulb');
+  });
+
+  test('renders numeric context values as strings in text fields', () => {
+    const t: DashboardCard = {
+      type: 'test',
+      title: 'Count: <%= context.count %>',
+    };
+    const card: DashboardCard = {
+      type: 'custom:linked-lovelace-template',
+      ll_template: 'num-tpl',
+      ll_context: { count: 42 },
+    };
+    const result = updateCardTemplate(card, { 'num-tpl': t });
+    expect(result.title).toBe('Count: 42');
+  });
+
+  test('renders boolean context values as string "true"/"false"', () => {
+    const t: DashboardCard = {
+      type: 'test',
+      active: '<%= context.on %>',
+    };
+    const card: DashboardCard = {
+      type: 'custom:linked-lovelace-template',
+      ll_template: 'bool-tpl',
+      ll_context: { on: true },
+    };
+    const result = updateCardTemplate(card, { 'bool-tpl': t });
+    expect(result.active).toBe('true');
+  });
+
+  test('missing context variable renders as the string "undefined"', () => {
+    // Eta (with autoEscape=false) renders undefined values as "undefined"
+    const t: DashboardCard = {
+      type: 'test',
+      name: '<%= context.missing %>',
+    };
+    const card: DashboardCard = {
+      type: 'custom:linked-lovelace-template',
+      ll_template: 'miss-tpl',
+      ll_context: {},
+    };
+    const result = updateCardTemplate(card, { 'miss-tpl': t });
+    expect(result.name).toBe('undefined');
+  });
+
+  test('conditional rendering with if/else', () => {
+    const t: DashboardCard = {
+      type: 'test',
+      icon: '<% if (context.active) { %>mdi:power<% } else { %>mdi:power-off<% } %>',
+    };
+    const cardOn: DashboardCard = {
+      type: 'custom:linked-lovelace-template',
+      ll_template: 'cond-tpl',
+      ll_context: { active: true },
+    };
+    const cardOff: DashboardCard = {
+      type: 'custom:linked-lovelace-template',
+      ll_template: 'cond-tpl',
+      ll_context: { active: false },
+    };
+    expect(updateCardTemplate(cardOn, { 'cond-tpl': t }).icon).toBe('mdi:power');
+    expect(updateCardTemplate(cardOff, { 'cond-tpl': t }).icon).toBe('mdi:power-off');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ll_template key is preserved in output
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] ll_template is always preserved in output', () => {
+  test('ll_template key stays after simple render', () => {
+    const template: DashboardCard = { type: 'button' };
+    const card: DashboardCard = { type: 'fake', ll_template: 'btn' };
+    const result = updateCardTemplate(card, { btn: template });
+    expect(result.ll_template).toBe('btn');
+  });
+
+  test('ll_template key stays after context render', () => {
+    const template: DashboardCard = { type: 'button', name: '<%= context.n %>' };
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'btn',
+      ll_context: { n: 'Hello' },
+    };
+    const result = updateCardTemplate(card, { btn: template });
+    expect(result.ll_template).toBe('btn');
+    expect(result.name).toBe('Hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ll_context inheritance via the parentContext parameter
+// Context flows to children when a NON-template card contains child cards.
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] ll_context inheritance via parentContext', () => {
+  test('parent context is passed down to child template cards', () => {
+    const childTemplate: DashboardCard = {
+      type: 'child',
+      name: '<%= context.shared %>',
+    };
+    // Outer card is NOT a template – it goes through the else-branch which
+    // iterates child cards with the accumulated parentContext.
+    const outerCard: DashboardCard = {
+      type: 'grid',
+      ll_context: { shared: 'from-parent' },
+      cards: [
+        {
+          type: 'fake',
+          ll_template: 'child-tpl',
+        },
+      ],
+    };
+    const templates = { 'child-tpl': childTemplate };
+    // parentContext starts empty; ll_context on the outer non-template card
+    // becomes the parentContext for its children via the dataFromTemplate spread.
+    // NOTE: ll_context on a non-template card merges into parentContext for children.
+    const result = updateCardTemplate(outerCard, templates, { shared: 'from-parent' });
+    expect(result.cards![0].name).toBe('from-parent');
+  });
+
+  test('child ll_context takes precedence over parent context for same key', () => {
+    const childTemplate: DashboardCard = {
+      type: 'child',
+      name: '<%= context.val %>',
+    };
+    const card: DashboardCard = {
+      type: 'grid',
+      cards: [
+        {
+          type: 'fake',
+          ll_template: 'child-tpl',
+          ll_context: { val: 'child-wins' },
+        },
+      ],
+    };
+    const result = updateCardTemplate(card, { 'child-tpl': childTemplate }, { val: 'parent' });
+    expect(result.cards![0].name).toBe('child-wins');
+  });
+
+  test('parentContext argument is used when card has no ll_context', () => {
+    const template: DashboardCard = { type: 'tile', label: '<%= context.inherited %>' };
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'tile-tpl',
+      // no ll_context
+    };
+    const result = updateCardTemplate(card, { 'tile-tpl': template }, { inherited: 'yes' });
+    expect(result.label).toBe('yes');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ll_context is NOT leaked into the template definition (bug #41)
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] ll_context is not leaked into template registry', () => {
+  test('rendering a card does not mutate the stored template object', () => {
+    const template: DashboardCard = {
+      type: 'button',
+      name: '<%= context.label %>',
+    };
+    const originalTemplate = JSON.parse(JSON.stringify(template));
+    const templates = { btn: template };
+
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'btn',
+      ll_context: { label: 'Test' },
+    };
+    updateCardTemplate(card, templates);
+
+    // The object in the registry must remain unchanged
+    expect(templates.btn).toStrictEqual(originalTemplate);
+    expect(templates.btn.ll_context).toBeUndefined();
+  });
+
+  test('rendering the same template twice with different contexts gives independent results', () => {
+    const template: DashboardCard = { type: 'label', text: '<%= context.msg %>' };
+    const templates = { lbl: template };
+
+    const r1 = updateCardTemplate(
+      { type: 'fake', ll_template: 'lbl', ll_context: { msg: 'Hello' } },
+      templates
+    );
+    const r2 = updateCardTemplate(
+      { type: 'fake', ll_template: 'lbl', ll_context: { msg: 'World' } },
+      templates
+    );
+
+    expect(r1.text).toBe('Hello');
+    expect(r2.text).toBe('World');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sections support (Home Assistant 2024.3+ dashboard layout)
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] sections support', () => {
+  test('renders templates inside a sections array', () => {
+    const template: DashboardCard = { type: 'tile', entity: '<%= context.entity %>' };
+    const card: DashboardCard = {
+      type: 'grid',
+      sections: [
+        {
+          type: 'section',
+          cards: [
+            {
+              type: 'fake',
+              ll_template: 'tile-tpl',
+              ll_context: { entity: 'light.kitchen' },
+            },
+          ],
+        },
+      ],
+    };
+    const result = updateCardTemplate(card, { 'tile-tpl': template });
+    expect(result.sections![0].cards![0].entity).toBe('light.kitchen');
+    expect(result.sections![0].cards![0].type).toBe('tile');
+  });
+
+  test('multiple cards in multiple sections are all rendered', () => {
+    const t: DashboardCard = { type: 'tile', entity: '<%= context.entity %>' };
+    const card: DashboardCard = {
+      type: 'grid',
+      sections: [
+        {
+          type: 'section',
+          cards: [
+            { type: 'fake', ll_template: 'tile-tpl', ll_context: { entity: 'light.a' } },
+            { type: 'fake', ll_template: 'tile-tpl', ll_context: { entity: 'light.b' } },
+          ],
+        },
+        {
+          type: 'section',
+          cards: [
+            { type: 'fake', ll_template: 'tile-tpl', ll_context: { entity: 'sensor.c' } },
+          ],
+        },
+      ],
+    };
+    const result = updateCardTemplate(card, { 'tile-tpl': t });
+    expect(result.sections![0].cards![0].entity).toBe('light.a');
+    expect(result.sections![0].cards![1].entity).toBe('light.b');
+    expect(result.sections![1].cards![0].entity).toBe('sensor.c');
+  });
+
+  test('sections without cards are left unchanged', () => {
+    const card: DashboardCard = {
+      type: 'grid',
+      sections: [{ type: 'section' }],
+    };
+    const result = updateCardTemplate(card, {});
+    expect(result.sections).toStrictEqual([{ type: 'section' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ll_keys – inject context values (including rendered template arrays) into
+// template properties. KEY = template property to override, VALUE = context
+// property to read (and render if it contains template cards).
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] ll_keys', () => {
+  test('ll_keys where key equals value overrides a scalar property', () => {
+    // When ll_keys: { number: 'number' }, sets data.number = context.number
+    const template: DashboardCard = { type: 'entity', number: 3 };
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'ent-tpl',
+      ll_context: { number: 99 },
+      ll_keys: { number: 'number' },
+    };
+    const result = updateCardTemplate(card, { 'ent-tpl': template });
+    expect(result.number).toBe(99);
+  });
+
+  test('ll_keys is preserved in the output', () => {
+    const template: DashboardCard = { type: 'entity' };
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'ent-tpl',
+      ll_context: {},
+      ll_keys: { foo: 'foo' },
+    };
+    const result = updateCardTemplate(card, { 'ent-tpl': template });
+    expect(result.ll_keys).toStrictEqual({ foo: 'foo' });
+  });
+
+  test('ll_keys with array of template cards renders each card in the array', () => {
+    const childTemplate: DashboardCard = { type: 'child', name: '<%= context.n %>' };
+    const parentTemplate: DashboardCard = { type: 'parent', cards: [] };
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'parent-tpl',
+      ll_context: {
+        cards: [{ ll_template: 'child-tpl', ll_context: { n: 'Alpha' } }],
+      },
+      ll_keys: { cards: 'cards' },
+    };
+    const result = updateCardTemplate(card, {
+      'parent-tpl': parentTemplate,
+      'child-tpl': childTemplate,
+    });
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards![0].type).toBe('child');
+    expect(result.cards![0].name).toBe('Alpha');
+  });
+
+  test('ll_keys with multiple array items each render independently', () => {
+    const itemTemplate: DashboardCard = { type: 'item', label: '<%= context.label %>' };
+    const parentTemplate: DashboardCard = { type: 'list', cards: [] };
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'list-tpl',
+      ll_context: {
+        cards: [
+          { ll_template: 'item-tpl', ll_context: { label: 'First' } },
+          { ll_template: 'item-tpl', ll_context: { label: 'Second' } },
+          { ll_template: 'item-tpl', ll_context: { label: 'Third' } },
+        ],
+      },
+      ll_keys: { cards: 'cards' },
+    };
+    const result = updateCardTemplate(card, {
+      'list-tpl': parentTemplate,
+      'item-tpl': itemTemplate,
+    });
+    expect(result.cards).toHaveLength(3);
+    expect(result.cards![0].label).toBe('First');
+    expect(result.cards![1].label).toBe('Second');
+    expect(result.cards![2].label).toBe('Third');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-ll cards – passthrough and recursive traversal
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] non-ll card passthrough and recursive traversal', () => {
+  test('plain card without ll_ keys is returned unchanged', () => {
+    const card: DashboardCard = {
+      type: 'button',
+      name: 'Hello',
+      tap_action: { action: 'toggle' },
+    };
+    expect(updateCardTemplate(card, {})).toStrictEqual(card);
+  });
+
+  test('nested objects are traversed recursively when no ll_template present', () => {
+    const template: DashboardCard = { type: 'tile', entity: 'sensor.x' };
+    const card: DashboardCard = {
+      type: 'container',
+      custom_config: {
+        content: {
+          type: 'fake',
+          ll_template: 'tile-tpl',
+        },
+      },
+    };
+    const result = updateCardTemplate(card, { 'tile-tpl': template });
+    expect(result.custom_config.content.type).toBe('tile');
+    expect(result.custom_config.content.entity).toBe('sensor.x');
+  });
+
+  test('deeply nested tap_action with ll_template is resolved', () => {
+    const popup: DashboardCard = { type: 'popup-content', title: '<%= context.ttl %>' };
+    const card: DashboardCard = {
+      type: 'button',
+      tap_action: {
+        action: 'fire-dom-event',
+        browser_mod: {
+          service: 'browser_mod.popup',
+          data: {
+            content: {
+              type: 'fake',
+              ll_template: 'popup-tpl',
+              ll_context: { ttl: 'My Popup' },
+            },
+          },
+        },
+      },
+    };
+    const result = updateCardTemplate(card, { 'popup-tpl': popup });
+    const content = result.tap_action.browser_mod.data.content;
+    expect(content.type).toBe('popup-content');
+    expect(content.title).toBe('My Popup');
+  });
+
+  test('card with ll_template that does not exist is returned unchanged', () => {
+    const card: DashboardCard = {
+      type: 'test',
+      ll_template: 'does-not-exist',
+    };
+    expect(updateCardTemplate(card, {})).toStrictEqual(card);
+  });
+
+  test('array values that are not objects are not mutated', () => {
+    const card: DashboardCard = {
+      type: 'custom:layout-card',
+      gridcols: [1, 2, 3],
+    };
+    const result = updateCardTemplate(card, {});
+    expect(result.gridcols).toStrictEqual([1, 2, 3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Priority ordering in LinkedLovelaceController
+// ---------------------------------------------------------------------------
+describe('[LinkedLovelaceController] template priority ordering', () => {
+  test('lower ll_priority templates are registered before higher ones', async () => {
+    const LinkedLovelaceController = (await import('../v2/linkedLovelace')).default;
+    const controller = new LinkedLovelaceController();
+    // Register in arbitrary order; 'high' should be processed last
+    // so it sees 'low' already in the registry.
+    controller.registerTemplates({
+      high: {
+        type: 'high',
+        ll_priority: 10,
+        cards: [{ type: 'fake', ll_template: 'low' }],
+      },
+      low: {
+        type: 'low',
+        ll_priority: 0,
+      },
+    });
+    // 'high' template's child card should have been rendered as 'low'
+    const highTemplate = controller.templateController.templates['high'];
+    expect(highTemplate.cards![0].type).toBe('low');
+  });
+
+  test('templates with equal priority preserve registration order', async () => {
+    const LinkedLovelaceController = (await import('../v2/linkedLovelace')).default;
+    const controller = new LinkedLovelaceController();
+    controller.registerTemplates({
+      a: { type: 'a', ll_priority: 5 },
+      b: { type: 'b', ll_priority: 5 },
+    });
+    expect(controller.templateController.templates['a'].type).toBe('a');
+    expect(controller.templateController.templates['b'].type).toBe('b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic / snapshot-style output – regression suite
+// These lock in exact expected output so regressions surface immediately.
+// ---------------------------------------------------------------------------
+describe('[updateCardTemplate] deterministic output – regression suite', () => {
+  const BUTTON_TEMPLATE: DashboardCard = {
+    type: 'custom:button-card',
+    entity: '<%= context.entity %>',
+    name: '<%= context.name %>',
+    icon: '<%= context.icon %>',
+    tap_action: { action: 'toggle' },
+  };
+
+  test('button template renders deterministically', () => {
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'btn',
+      ll_context: {
+        entity: 'light.living_room',
+        name: 'Living Room',
+        icon: 'mdi:sofa',
+      },
+    };
+    const result = updateCardTemplate(card, { btn: BUTTON_TEMPLATE });
+    expect(result).toStrictEqual({
+      type: 'custom:button-card',
+      ll_template: 'btn',
+      ll_context: { entity: 'light.living_room', name: 'Living Room', icon: 'mdi:sofa' },
+      entity: 'light.living_room',
+      name: 'Living Room',
+      icon: 'mdi:sofa',
+      tap_action: { action: 'toggle' },
+    });
+  });
+
+  test('two renders with identical input produce identical output', () => {
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'btn',
+      ll_context: { entity: 'sensor.temp', name: 'Temp', icon: 'mdi:thermometer' },
+    };
+    const r1 = updateCardTemplate(card, { btn: BUTTON_TEMPLATE });
+    const r2 = updateCardTemplate(card, { btn: BUTTON_TEMPLATE });
+    expect(r1).toStrictEqual(r2);
+  });
+
+  test('different contexts produce different outputs', () => {
+    const card1: DashboardCard = {
+      type: 'fake',
+      ll_template: 'btn',
+      ll_context: { entity: 'light.a', name: 'A', icon: 'mdi:a' },
+    };
+    const card2: DashboardCard = {
+      type: 'fake',
+      ll_template: 'btn',
+      ll_context: { entity: 'light.b', name: 'B', icon: 'mdi:b' },
+    };
+    const r1 = updateCardTemplate(card1, { btn: BUTTON_TEMPLATE });
+    const r2 = updateCardTemplate(card2, { btn: BUTTON_TEMPLATE });
+    expect(r1.name).toBe('A');
+    expect(r2.name).toBe('B');
+    expect(r1).not.toStrictEqual(r2);
+  });
+
+  test('template with no context variables renders without substitution', () => {
+    const staticTemplate: DashboardCard = {
+      type: 'weather-forecast',
+      entity: 'weather.home',
+      forecast_type: 'daily',
+    };
+    const card: DashboardCard = {
+      type: 'fake',
+      ll_template: 'weather',
+    };
+    const result = updateCardTemplate(card, { weather: staticTemplate });
+    expect(result.type).toBe('weather-forecast');
+    expect(result.entity).toBe('weather.home');
+    expect(result.forecast_type).toBe('daily');
+    expect(result.ll_template).toBe('weather');
+  });
+
+  test('view with mix of template and plain cards renders correctly', () => {
+    const btnTemplate: DashboardCard = { type: 'button', name: '<%= context.n %>' };
+    const view: DashboardView = {
+      title: 'Living Room',
+      cards: [
+        { type: 'markdown', content: '# Hello' },
+        { type: 'fake', ll_template: 'btn', ll_context: { n: 'Toggle' } },
+        { type: 'weather-forecast', entity: 'weather.home' },
+      ],
+    };
+    // Simulate rendering a view by updating each card
+    const rendered = view.cards!.map((c) =>
+      updateCardTemplate(c, { btn: btnTemplate })
+    );
+    expect(rendered[0].type).toBe('markdown');
+    expect(rendered[1].type).toBe('button');
+    expect(rendered[1].name).toBe('Toggle');
+    expect(rendered[2].type).toBe('weather-forecast');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TemplateEngine singleton consistency
+// ---------------------------------------------------------------------------
+describe('[TemplateEngine] singleton', () => {
+  test('TemplateEngine.instance always returns the same object', async () => {
+    const { TemplateEngine } = await import('../v2/template-engine');
+    const a = TemplateEngine.instance;
+    const b = TemplateEngine.instance;
+    expect(a).toBe(b);
+  });
+
+  test('refresh() replaces the eta engine with a fresh instance', async () => {
+    const { TemplateEngine } = await import('../v2/template-engine');
+    const engine = new TemplateEngine();
+    const originalEta = engine.eta;
+    engine.refresh();
+    expect(engine.eta).not.toBe(originalEta);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,137 +2,6 @@
 # yarn lockfile v1
 
 
-"@algolia/autocomplete-core@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz#1d56482a768c33aae0868c8533049e02e8961be7"
-  integrity sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==
-  dependencies:
-    "@algolia/autocomplete-plugin-algolia-insights" "1.9.3"
-    "@algolia/autocomplete-shared" "1.9.3"
-
-"@algolia/autocomplete-plugin-algolia-insights@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz#9b7f8641052c8ead6d66c1623d444cbe19dde587"
-  integrity sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==
-  dependencies:
-    "@algolia/autocomplete-shared" "1.9.3"
-
-"@algolia/autocomplete-preset-algolia@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz#64cca4a4304cfcad2cf730e83067e0c1b2f485da"
-  integrity sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==
-  dependencies:
-    "@algolia/autocomplete-shared" "1.9.3"
-
-"@algolia/autocomplete-shared@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz#2e22e830d36f0a9cf2c0ccd3c7f6d59435b77dfa"
-  integrity sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==
-
-"@algolia/cache-browser-local-storage@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz#14b6dc9abc9e3a304a5fffb063d15f30af1032d1"
-  integrity sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==
-  dependencies:
-    "@algolia/cache-common" "4.22.1"
-
-"@algolia/cache-common@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.22.1.tgz#c625dff4bc2a74e79f9aed67b4e053b0ef1b3ec1"
-  integrity sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA==
-
-"@algolia/cache-in-memory@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz#858a3d887f521362e87d04f3943e2810226a0d71"
-  integrity sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==
-  dependencies:
-    "@algolia/cache-common" "4.22.1"
-
-"@algolia/client-account@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.22.1.tgz#a7fb8b66b9a4f0a428e1426b2561144267d76d43"
-  integrity sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==
-  dependencies:
-    "@algolia/client-common" "4.22.1"
-    "@algolia/client-search" "4.22.1"
-    "@algolia/transporter" "4.22.1"
-
-"@algolia/client-analytics@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.22.1.tgz#506558740b4d49b1b1e3393861f729a8ce921851"
-  integrity sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==
-  dependencies:
-    "@algolia/client-common" "4.22.1"
-    "@algolia/client-search" "4.22.1"
-    "@algolia/requester-common" "4.22.1"
-    "@algolia/transporter" "4.22.1"
-
-"@algolia/client-common@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.22.1.tgz#042b19c1b6157c485fa1b551349ab313944d2b05"
-  integrity sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==
-  dependencies:
-    "@algolia/requester-common" "4.22.1"
-    "@algolia/transporter" "4.22.1"
-
-"@algolia/client-personalization@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-4.22.1.tgz#ff088d797648224fb582e9fe5828f8087835fa3d"
-  integrity sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==
-  dependencies:
-    "@algolia/client-common" "4.22.1"
-    "@algolia/requester-common" "4.22.1"
-    "@algolia/transporter" "4.22.1"
-
-"@algolia/client-search@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.22.1.tgz#508cc6ab3d1f4e9c02735a630d4dff6fbb8514a2"
-  integrity sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==
-  dependencies:
-    "@algolia/client-common" "4.22.1"
-    "@algolia/requester-common" "4.22.1"
-    "@algolia/transporter" "4.22.1"
-
-"@algolia/logger-common@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.22.1.tgz#79cf4cd295de0377a94582c6aaac59b1ded731d9"
-  integrity sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg==
-
-"@algolia/logger-console@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.22.1.tgz#0355345f6940f67aaa78ae9b81c06e44e49f2336"
-  integrity sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==
-  dependencies:
-    "@algolia/logger-common" "4.22.1"
-
-"@algolia/requester-browser-xhr@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz#f04df6fe9690a071b267c77d26b83a3be9280361"
-  integrity sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==
-  dependencies:
-    "@algolia/requester-common" "4.22.1"
-
-"@algolia/requester-common@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.22.1.tgz#27be35f3718aafcb6b388ff9c3aa2defabd559ff"
-  integrity sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg==
-
-"@algolia/requester-node-http@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz#589a6fa828ad0f325e727a6fcaf4e1a2343cc62b"
-  integrity sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==
-  dependencies:
-    "@algolia/requester-common" "4.22.1"
-
-"@algolia/transporter@4.22.1":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.22.1.tgz#8843841b857dc021668f31647aa557ff19cd9cb1"
-  integrity sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==
-  dependencies:
-    "@algolia/cache-common" "4.22.1"
-    "@algolia/logger-common" "4.22.1"
-    "@algolia/requester-common" "4.22.1"
-
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -477,11 +346,6 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.5.tgz#721fd042f3ce1896238cf1b341c77eb7dee7dbea"
   integrity sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==
 
-"@babel/parser@^7.23.9":
-  version "7.24.1"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.1.tgz#1e416d3627393fab1cb5b0f2f1796a100ae9133a"
-  integrity sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==
-
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
@@ -668,144 +532,6 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
-
-"@docsearch/css@3.6.0", "@docsearch/css@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.6.0.tgz#0e9f56f704b3a34d044d15fd9962ebc1536ba4fb"
-  integrity sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ==
-
-"@docsearch/js@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@docsearch/js/-/js-3.6.0.tgz#f9e46943449b9092d874944f7a80bcc071004cfb"
-  integrity sha512-QujhqINEElrkIfKwyyyTfbsfMAYCkylInLYMRqHy7PHc8xTBQCow73tlo/Kc7oIwBrCLf0P3YhjlOeV4v8hevQ==
-  dependencies:
-    "@docsearch/react" "3.6.0"
-    preact "^10.0.0"
-
-"@docsearch/react@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.6.0.tgz#b4f25228ecb7fc473741aefac592121e86dd2958"
-  integrity sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==
-  dependencies:
-    "@algolia/autocomplete-core" "1.9.3"
-    "@algolia/autocomplete-preset-algolia" "1.9.3"
-    "@docsearch/css" "3.6.0"
-    algoliasearch "^4.19.1"
-
-"@esbuild/aix-ppc64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz#a70f4ac11c6a1dfc18b8bbb13284155d933b9537"
-  integrity sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==
-
-"@esbuild/android-arm64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz#db1c9202a5bc92ea04c7b6840f1bbe09ebf9e6b9"
-  integrity sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==
-
-"@esbuild/android-arm@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.20.2.tgz#3b488c49aee9d491c2c8f98a909b785870d6e995"
-  integrity sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==
-
-"@esbuild/android-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.20.2.tgz#3b1628029e5576249d2b2d766696e50768449f98"
-  integrity sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==
-
-"@esbuild/darwin-arm64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz#6e8517a045ddd86ae30c6608c8475ebc0c4000bb"
-  integrity sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==
-
-"@esbuild/darwin-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz#90ed098e1f9dd8a9381695b207e1cff45540a0d0"
-  integrity sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==
-
-"@esbuild/freebsd-arm64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz#d71502d1ee89a1130327e890364666c760a2a911"
-  integrity sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==
-
-"@esbuild/freebsd-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz#aa5ea58d9c1dd9af688b8b6f63ef0d3d60cea53c"
-  integrity sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==
-
-"@esbuild/linux-arm64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz#055b63725df678379b0f6db9d0fa85463755b2e5"
-  integrity sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==
-
-"@esbuild/linux-arm@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz#76b3b98cb1f87936fbc37f073efabad49dcd889c"
-  integrity sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==
-
-"@esbuild/linux-ia32@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz#c0e5e787c285264e5dfc7a79f04b8b4eefdad7fa"
-  integrity sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==
-
-"@esbuild/linux-loong64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz#a6184e62bd7cdc63e0c0448b83801001653219c5"
-  integrity sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==
-
-"@esbuild/linux-mips64el@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz#d08e39ce86f45ef8fc88549d29c62b8acf5649aa"
-  integrity sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==
-
-"@esbuild/linux-ppc64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz#8d252f0b7756ffd6d1cbde5ea67ff8fd20437f20"
-  integrity sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==
-
-"@esbuild/linux-riscv64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz#19f6dcdb14409dae607f66ca1181dd4e9db81300"
-  integrity sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==
-
-"@esbuild/linux-s390x@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz#3c830c90f1a5d7dd1473d5595ea4ebb920988685"
-  integrity sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==
-
-"@esbuild/linux-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz#86eca35203afc0d9de0694c64ec0ab0a378f6fff"
-  integrity sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==
-
-"@esbuild/netbsd-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz#e771c8eb0e0f6e1877ffd4220036b98aed5915e6"
-  integrity sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==
-
-"@esbuild/openbsd-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz#9a795ae4b4e37e674f0f4d716f3e226dd7c39baf"
-  integrity sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==
-
-"@esbuild/sunos-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz#7df23b61a497b8ac189def6e25a95673caedb03f"
-  integrity sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==
-
-"@esbuild/win32-arm64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz#f1ae5abf9ca052ae11c1bc806fb4c0f519bacf90"
-  integrity sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==
-
-"@esbuild/win32-ia32@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz#241fe62c34d8e8461cd708277813e1d0ba55ce23"
-  integrity sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==
-
-"@esbuild/win32-x64@0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz#9c907b21e30a52db959ba4f80bb01a0cc403d5cc"
-  integrity sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==
 
 "@formatjs/ecma402-abstract@1.11.4":
   version "1.11.4"
@@ -1119,11 +845,6 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/sourcemap-codec@^1.4.15":
-  version "1.4.15"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
-  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
-
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
@@ -1202,83 +923,6 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rollup/rollup-android-arm-eabi@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz#b98786c1304b4ff8db3a873180b778649b5dff2b"
-  integrity sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==
-
-"@rollup/rollup-android-arm64@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz#8833679af11172b1bf1ab7cb3bad84df4caf0c9e"
-  integrity sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==
-
-"@rollup/rollup-darwin-arm64@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz#ef02d73e0a95d406e0eb4fd61a53d5d17775659b"
-  integrity sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==
-
-"@rollup/rollup-darwin-x64@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz#3ce5b9bcf92b3341a5c1c58a3e6bcce0ea9e7455"
-  integrity sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz#3d3d2c018bdd8e037c6bfedd52acfff1c97e4be4"
-  integrity sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==
-
-"@rollup/rollup-linux-arm64-gnu@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz#5fc8cc978ff396eaa136d7bfe05b5b9138064143"
-  integrity sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==
-
-"@rollup/rollup-linux-arm64-musl@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz#f2ae7d7bed416ffa26d6b948ac5772b520700eef"
-  integrity sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==
-
-"@rollup/rollup-linux-riscv64-gnu@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz#303d57a328ee9a50c85385936f31cf62306d30b6"
-  integrity sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==
-
-"@rollup/rollup-linux-x64-gnu@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz#f672f6508f090fc73f08ba40ff76c20b57424778"
-  integrity sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==
-
-"@rollup/rollup-linux-x64-musl@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz#d2f34b1b157f3e7f13925bca3288192a66755a89"
-  integrity sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==
-
-"@rollup/rollup-win32-arm64-msvc@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz#8ffecc980ae4d9899eb2f9c4ae471a8d58d2da6b"
-  integrity sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==
-
-"@rollup/rollup-win32-ia32-msvc@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz#a7505884f415662e088365b9218b2b03a88fc6f2"
-  integrity sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==
-
-"@rollup/rollup-win32-x64-msvc@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz#6abd79db7ff8d01a58865ba20a63cfd23d9e2a10"
-  integrity sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==
-
-"@shikijs/core@1.2.0", "@shikijs/core@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-1.2.0.tgz#c19d1a4d4807d31aa02e9d822aa13da873e6f2e7"
-  integrity sha512-OlFvx+nyr5C8zpcMBnSGir0YPD6K11uYhouqhNmm1qLiis4GA7SsGtu07r9gKS9omks8RtQqHrJL4S+lqWK01A==
-
-"@shikijs/transformers@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/transformers/-/transformers-1.2.0.tgz#954cbb20324be55340701f56b5815aa454fbdd05"
-  integrity sha512-xKn7DtA65DQV4FOfYsrvqM80xOy2xuXnxWWKsZmHv1VII/IOuDUDsWDu3KnpeLH6wqNJWp1GRoNUsHR1aw/VhQ==
-  dependencies:
-    shiki "1.2.0"
-
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
@@ -1356,11 +1000,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
   integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
-"@types/estree@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
-  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
-
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1395,24 +1034,6 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/linkify-it@*":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.5.tgz#1e78a3ac2428e6d7e6c05c1665c242023a4601d8"
-  integrity sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==
-
-"@types/markdown-it@^13.0.7":
-  version "13.0.7"
-  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-13.0.7.tgz#4a495115f470075bd4434a0438ac477a49c2e152"
-  integrity sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==
-  dependencies:
-    "@types/linkify-it" "*"
-    "@types/mdurl" "*"
-
-"@types/mdurl@*":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.5.tgz#3e0d2db570e9fb6ccb2dc8fde0be1d79ac810d39"
-  integrity sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==
-
 "@types/node@*":
   version "12.7.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
@@ -1440,11 +1061,6 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
-"@types/web-bluetooth@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
-  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
-
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -1457,146 +1073,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vitejs/plugin-vue@^5.0.4":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz#508d6a0f2440f86945835d903fcc0d95d1bb8a37"
-  integrity sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==
-
-"@vue/compiler-core@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.4.21.tgz#868b7085378fc24e58c9aed14c8d62110a62be1a"
-  integrity sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==
-  dependencies:
-    "@babel/parser" "^7.23.9"
-    "@vue/shared" "3.4.21"
-    entities "^4.5.0"
-    estree-walker "^2.0.2"
-    source-map-js "^1.0.2"
-
-"@vue/compiler-dom@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz#0077c355e2008207283a5a87d510330d22546803"
-  integrity sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==
-  dependencies:
-    "@vue/compiler-core" "3.4.21"
-    "@vue/shared" "3.4.21"
-
-"@vue/compiler-sfc@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz#4af920dc31ab99e1ff5d152b5fe0ad12181145b2"
-  integrity sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==
-  dependencies:
-    "@babel/parser" "^7.23.9"
-    "@vue/compiler-core" "3.4.21"
-    "@vue/compiler-dom" "3.4.21"
-    "@vue/compiler-ssr" "3.4.21"
-    "@vue/shared" "3.4.21"
-    estree-walker "^2.0.2"
-    magic-string "^0.30.7"
-    postcss "^8.4.35"
-    source-map-js "^1.0.2"
-
-"@vue/compiler-ssr@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz#b84ae64fb9c265df21fc67f7624587673d324fef"
-  integrity sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==
-  dependencies:
-    "@vue/compiler-dom" "3.4.21"
-    "@vue/shared" "3.4.21"
-
-"@vue/devtools-api@^7.0.16":
-  version "7.0.20"
-  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-7.0.20.tgz#fd79229b917f0284e7341e6d4e1ae403aac9232a"
-  integrity sha512-DGEIdotTQFll4187YGc/0awcag7UGJu9M6rE1Pxcs8AX/sGm0Ikk7UqQELmqYsyPzTT9s6OZzSPuBc4OatOXKA==
-  dependencies:
-    "@vue/devtools-kit" "^7.0.20"
-
-"@vue/devtools-kit@^7.0.20":
-  version "7.0.20"
-  resolved "https://registry.yarnpkg.com/@vue/devtools-kit/-/devtools-kit-7.0.20.tgz#e8502bd275004654100a29e2b98ef0e0c904bd0d"
-  integrity sha512-FgFuPuqrhQ51rR/sVi52FnGgrxJ3X1bvNra/SkBzPhxJVhfyL5w2YUJZI1FgCvtLAyPSomJNdvlG415ZbJsr6w==
-  dependencies:
-    "@vue/devtools-shared" "^7.0.20"
-    hookable "^5.5.3"
-    mitt "^3.0.1"
-    perfect-debounce "^1.0.0"
-    speakingurl "^14.0.1"
-
-"@vue/devtools-shared@^7.0.20":
-  version "7.0.20"
-  resolved "https://registry.yarnpkg.com/@vue/devtools-shared/-/devtools-shared-7.0.20.tgz#270d4f1095f7c536ebc4b3eeb89be9a8e195a608"
-  integrity sha512-E6CiCaYr6ZWOCYJgWodXcPCXxB12vgbUA1X1sG0F1tK5Bo5I35GJuTR8LBJLFHV0VpwLWvyrIi9drT1ZbuJxlg==
-  dependencies:
-    rfdc "^1.3.1"
-
-"@vue/reactivity@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.4.21.tgz#affd3415115b8ebf4927c8d2a0d6a24bccfa9f02"
-  integrity sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==
-  dependencies:
-    "@vue/shared" "3.4.21"
-
-"@vue/runtime-core@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.4.21.tgz#3749c3f024a64c4c27ecd75aea4ca35634db0062"
-  integrity sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==
-  dependencies:
-    "@vue/reactivity" "3.4.21"
-    "@vue/shared" "3.4.21"
-
-"@vue/runtime-dom@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz#91f867ef64eff232cac45095ab28ebc93ac74588"
-  integrity sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==
-  dependencies:
-    "@vue/runtime-core" "3.4.21"
-    "@vue/shared" "3.4.21"
-    csstype "^3.1.3"
-
-"@vue/server-renderer@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.4.21.tgz#150751579d26661ee3ed26a28604667fa4222a97"
-  integrity sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==
-  dependencies:
-    "@vue/compiler-ssr" "3.4.21"
-    "@vue/shared" "3.4.21"
-
-"@vue/shared@3.4.21":
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.21.tgz#de526a9059d0a599f0b429af7037cd0c3ed7d5a1"
-  integrity sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==
-
-"@vueuse/core@10.9.0", "@vueuse/core@^10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.9.0.tgz#7d779a95cf0189de176fee63cee4ba44b3c85d64"
-  integrity sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==
-  dependencies:
-    "@types/web-bluetooth" "^0.0.20"
-    "@vueuse/metadata" "10.9.0"
-    "@vueuse/shared" "10.9.0"
-    vue-demi ">=0.14.7"
-
-"@vueuse/integrations@^10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/integrations/-/integrations-10.9.0.tgz#2b1a9556215ad3c1f96d39cbfbef102cf6e0ec05"
-  integrity sha512-acK+A01AYdWSvL4BZmCoJAcyHJ6EqhmkQEXbQLwev1MY7NBnS+hcEMx/BzVoR9zKI+UqEPMD9u6PsyAuiTRT4Q==
-  dependencies:
-    "@vueuse/core" "10.9.0"
-    "@vueuse/shared" "10.9.0"
-    vue-demi ">=0.14.7"
-
-"@vueuse/metadata@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.9.0.tgz#769a1a9db65daac15cf98084cbf7819ed3758620"
-  integrity sha512-iddNbg3yZM0X7qFY2sAotomgdHK7YJ6sKUvQqbvwnf7TmaVPxS4EJydcNsVejNdS8iWCtDk+fYXr7E32nyTnGA==
-
-"@vueuse/shared@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.9.0.tgz#13af2a348de15d07b7be2fd0c7fc9853a69d8fe0"
-  integrity sha512-Uud2IWncmAfJvRaFYzv5OHDli+FbOzxiVEQdLCKQKLyhz94PIyFC3CHcH7EDMwIn8NPtD06+PNbC/PiO0LGLtw==
-  dependencies:
-    vue-demi ">=0.14.7"
-
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
@@ -1606,26 +1082,6 @@ acorn@^8.4.1:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
   integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
-
-algoliasearch@^4.19.1:
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.22.1.tgz#f10fbecdc7654639ec20d62f109c1b3a46bc6afc"
-  integrity sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==
-  dependencies:
-    "@algolia/cache-browser-local-storage" "4.22.1"
-    "@algolia/cache-common" "4.22.1"
-    "@algolia/cache-in-memory" "4.22.1"
-    "@algolia/client-account" "4.22.1"
-    "@algolia/client-analytics" "4.22.1"
-    "@algolia/client-common" "4.22.1"
-    "@algolia/client-personalization" "4.22.1"
-    "@algolia/client-search" "4.22.1"
-    "@algolia/logger-common" "4.22.1"
-    "@algolia/logger-console" "4.22.1"
-    "@algolia/requester-browser-xhr" "4.22.1"
-    "@algolia/requester-common" "4.22.1"
-    "@algolia/requester-node-http" "4.22.1"
-    "@algolia/transporter" "4.22.1"
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -1992,11 +1448,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-csstype@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
-  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
-
 custom-card-helpers@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/custom-card-helpers/-/custom-card-helpers-1.9.0.tgz#dac7bb7a531101f4c83096b26a8be8ccad70d8c0"
@@ -2092,11 +1543,6 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-entities@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
-  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
-
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -2161,35 +1607,6 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-esbuild@^0.20.1:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.20.2.tgz#9d6b2386561766ee6b5a55196c6d766d28c87ea1"
-  integrity sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==
-  optionalDependencies:
-    "@esbuild/aix-ppc64" "0.20.2"
-    "@esbuild/android-arm" "0.20.2"
-    "@esbuild/android-arm64" "0.20.2"
-    "@esbuild/android-x64" "0.20.2"
-    "@esbuild/darwin-arm64" "0.20.2"
-    "@esbuild/darwin-x64" "0.20.2"
-    "@esbuild/freebsd-arm64" "0.20.2"
-    "@esbuild/freebsd-x64" "0.20.2"
-    "@esbuild/linux-arm" "0.20.2"
-    "@esbuild/linux-arm64" "0.20.2"
-    "@esbuild/linux-ia32" "0.20.2"
-    "@esbuild/linux-loong64" "0.20.2"
-    "@esbuild/linux-mips64el" "0.20.2"
-    "@esbuild/linux-ppc64" "0.20.2"
-    "@esbuild/linux-riscv64" "0.20.2"
-    "@esbuild/linux-s390x" "0.20.2"
-    "@esbuild/linux-x64" "0.20.2"
-    "@esbuild/netbsd-x64" "0.20.2"
-    "@esbuild/openbsd-x64" "0.20.2"
-    "@esbuild/sunos-x64" "0.20.2"
-    "@esbuild/win32-arm64" "0.20.2"
-    "@esbuild/win32-ia32" "0.20.2"
-    "@esbuild/win32-x64" "0.20.2"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -2302,13 +1719,6 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-focus-trap@^7.5.4:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.5.4.tgz#6c4e342fe1dae6add9c2aa332a6e7a0bbd495ba2"
-  integrity sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==
-  dependencies:
-    tabbable "^6.2.0"
-
 follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
@@ -2356,11 +1766,6 @@ fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
-fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2539,11 +1944,6 @@ home-assistant-js-websocket@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-8.0.1.tgz#4c91f6e740600de9a59e0da3f018ea3487568415"
   integrity sha512-CVi1yu4+hj3m3+ZxgzEYiP+UYFmjf/iAsUKVyCmhVm9T8Pn7ZCeW16O3pniC4h1DOmTuXW+z4v373UwKxVOMAg==
-
-hookable@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/hookable/-/hookable-5.5.3.tgz#6cfc358984a1ef991e2518cb9ed4a778bbd3215d"
-  integrity sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -3306,13 +2706,6 @@ magic-string@^0.25.2, magic-string@^0.25.3:
   dependencies:
     sourcemap-codec "^1.4.8"
 
-magic-string@^0.30.7:
-  version "0.30.8"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.8.tgz#14e8624246d2bedba70d5462aa99ac9681844613"
-  integrity sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.15"
-
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -3331,11 +2724,6 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
-
-mark.js@8.11.1:
-  version "8.11.1"
-  resolved "https://registry.yarnpkg.com/mark.js/-/mark.js-8.11.1.tgz#180f1f9ebef8b0e638e4166ad52db879beb2ffc5"
-  integrity sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -3398,16 +2786,6 @@ minimatch@^9.0.1:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-6.0.2.tgz#542844b6c4ce95b202c0995b0a471f1229de4c81"
   integrity sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==
 
-minisearch@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-6.3.0.tgz#985a2f1ca3c73c2d65af94f0616bfe57164b0b6b"
-  integrity sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ==
-
-mitt@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
-  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -3417,11 +2795,6 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-nanoid@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
-  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3563,11 +2936,6 @@ path-scurry@^1.7.0:
     lru-cache "^9.1.1"
     minipass "^5.0.0 || ^6.0.2"
 
-perfect-debounce@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/perfect-debounce/-/perfect-debounce-1.0.0.tgz#9c2e8bc30b169cc984a58b7d5b28049839591d2a"
-  integrity sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -3594,20 +2962,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-postcss@^8.4.35, postcss@^8.4.36:
-  version "8.4.38"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
-  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.0.0"
-    source-map-js "^1.2.0"
-
-preact@^10.0.0:
-  version "10.20.0"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.20.0.tgz#191c10a2ee3b9fca1a7ded6375266266380212f6"
-  integrity sha512-wU7iZw2BjsaKDal3pDRDy/HpPB6cuFOnVUCcw9aIPKG98+ZrXx3F+szkos8BVME5bquyKDKvRlOJFG8kMkcAbg==
 
 pretty-format@^29.0.0, pretty-format@^29.5.0:
   version "29.5.0"
@@ -3700,11 +3054,6 @@ resolve@^1.20.0:
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
-
-rfdc@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.1.tgz#2b6d4df52dffe8bb346992a10ea9451f24373a8f"
-  integrity sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==
 
 rimraf@^5.0.1:
   version "5.0.1"
@@ -3822,28 +3171,6 @@ rollup@^3.25.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rollup@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.13.0.tgz#dd2ae144b4cdc2ea25420477f68d4937a721237a"
-  integrity sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==
-  dependencies:
-    "@types/estree" "1.0.5"
-  optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.13.0"
-    "@rollup/rollup-android-arm64" "4.13.0"
-    "@rollup/rollup-darwin-arm64" "4.13.0"
-    "@rollup/rollup-darwin-x64" "4.13.0"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.13.0"
-    "@rollup/rollup-linux-arm64-gnu" "4.13.0"
-    "@rollup/rollup-linux-arm64-musl" "4.13.0"
-    "@rollup/rollup-linux-riscv64-gnu" "4.13.0"
-    "@rollup/rollup-linux-x64-gnu" "4.13.0"
-    "@rollup/rollup-linux-x64-musl" "4.13.0"
-    "@rollup/rollup-win32-arm64-msvc" "4.13.0"
-    "@rollup/rollup-win32-ia32-msvc" "4.13.0"
-    "@rollup/rollup-win32-x64-msvc" "4.13.0"
-    fsevents "~2.3.2"
-
 safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -3908,13 +3235,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki@1.2.0, shiki@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-1.2.0.tgz#7f1b6917cbb10daa1ac3ae62fa29b40c494e2812"
-  integrity sha512-xLhiTMOIUXCv5DqJ4I70GgQCtdlzsTqFLZWcMHHG3TAieBUbvEGthdrlPDlX4mL/Wszx9C6rEcxU6kMlg4YlxA==
-  dependencies:
-    "@shikijs/core" "1.2.0"
-
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -3943,11 +3263,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-source-map-js@^1.0.2, source-map-js@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
-  integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
 source-map-support@0.5.13:
   version "0.5.13"
@@ -3980,11 +3295,6 @@ sourcemap-codec@^1.4.8:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-speakingurl@^14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/speakingurl/-/speakingurl-14.0.1.tgz#f37ec8ddc4ab98e9600c1c9ec324a8c48d772a53"
-  integrity sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -4005,7 +3315,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4062,7 +3381,14 @@ string.prototype.trimstart@^1.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4121,11 +3447,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-tabbable@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
-  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
 terser@^5.0.0:
   version "5.9.0"
@@ -4271,54 +3592,6 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
-vite@^5.2.2:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.2.3.tgz#198efc2fd4d80eac813b146a68a4b0dbde884fc2"
-  integrity sha512-+i1oagbvkVIhEy9TnEV+fgXsng13nZM90JQbrcPrf6DvW2mXARlz+DK7DLiDP+qeKoD1FCVx/1SpFL1CLq9Mhw==
-  dependencies:
-    esbuild "^0.20.1"
-    postcss "^8.4.36"
-    rollup "^4.13.0"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vitepress@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.1.tgz#828fe140d5f4975154845b31e97437f035a36c69"
-  integrity sha512-eNr5pOBppYUUjEhv8S0S2t9Tv95LQ6mMeHj6ivaGwfHxpov70Vduuwl/QQMDRznKDSaP0WKV7a82Pb4JVOaqEw==
-  dependencies:
-    "@docsearch/css" "^3.6.0"
-    "@docsearch/js" "^3.6.0"
-    "@shikijs/core" "^1.2.0"
-    "@shikijs/transformers" "^1.2.0"
-    "@types/markdown-it" "^13.0.7"
-    "@vitejs/plugin-vue" "^5.0.4"
-    "@vue/devtools-api" "^7.0.16"
-    "@vueuse/core" "^10.9.0"
-    "@vueuse/integrations" "^10.9.0"
-    focus-trap "^7.5.4"
-    mark.js "8.11.1"
-    minisearch "^6.3.0"
-    shiki "^1.2.0"
-    vite "^5.2.2"
-    vue "^3.4.21"
-
-vue-demi@>=0.14.7:
-  version "0.14.7"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.7.tgz#8317536b3ef74c5b09f268f7782e70194567d8f2"
-  integrity sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==
-
-vue@^3.4.21:
-  version "3.4.21"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.4.21.tgz#69ec30e267d358ee3a0ce16612ba89e00aaeb731"
-  integrity sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==
-  dependencies:
-    "@vue/compiler-dom" "3.4.21"
-    "@vue/compiler-sfc" "3.4.21"
-    "@vue/runtime-dom" "3.4.21"
-    "@vue/server-renderer" "3.4.21"
-    "@vue/shared" "3.4.21"
-
 walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
@@ -4356,7 +3629,16 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Tests (src/):
- Fix eta.test.ts URL test with axios mock so suite is network-free
- Add src/helpers/templates.extended.test.ts with 33 new tests covering:
  * Context variable substitution (strings, numbers, booleans, missing keys, conditionals)
  * ll_template preservation in all output paths
  * ll_context inheritance via parentContext parameter
  * ll_context mutation guard (regression for bug #41)
  * Sections support (HA 2024.3+ layout) – single and multi-section
  * ll_keys – scalar override, preservation, array-of-cards rendering, multi-item arrays
  * Non-ll card passthrough and deep recursive traversal
  * Priority ordering via LinkedLovelaceController.registerTemplates
  * Deterministic output regression suite (same input → same output, different inputs → different outputs)
  * TemplateEngine singleton and refresh()

Total: 69 → 102 tests, all green.

Docs (docs_site/):
- api-reference.md  – full property tables for all three card types, source card keys (ll_key, ll_priority, ll_context, ll_keys), template syntax summary, and rendering-order explanation
- template-syntax.md – Eta JS quick-reference with copy-paste examples: variables, defaults, conditionals, loops, partials, complex objects, and a full Mushroom chip example
- advanced-features.md – ll_keys in depth, priority ordering, nested template patterns, partials, context inheritance, status card details, and V1→V2 migration table
- troubleshooting.md – sections for plugin not loading, template not found, "undefined" output, sync issues, unexpected diffs, partial failures, ll_keys not injecting, persistence, and debugging tips
- index.md – updated hero tagline and feature list to reflect current capabilities including sections support and test coverage
- .vitepress/config.mts – top nav with API Reference link; sidebar split into Quick Start / Reference / Guides sections; local search; footer

https://claude.ai/code/session_01KuRANo5PTBm91uextMzw4b